### PR TITLE
feat: healthcheck

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -82,7 +82,7 @@ func main() {
 		&saveConfigFlag,
 		&disableDefaultConfigVars,
 		&allowDeprecatedFields,
-    &healthcheckPort,
+		&healthcheckPort,
 	}
 	app.Commands = []*cli.Command{
 		{

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -15,6 +15,8 @@ const appName = "cdk"
 const (
 	// NETWORK_CONFIGFILE name to identify the network_custom (genesis) config-file
 	NETWORK_CONFIGFILE = "custom_network" //nolint:stylecheck
+
+	HealthzPort = 3000
 )
 
 var (
@@ -67,7 +69,7 @@ var (
 		Name:     "healthcheckPort",
 		Usage:    "Specify port for healthcheck. Default is 3000.",
 		Required: false,
-		Value:    3000,
+		Value:    HealthzPort,
 	}
 )
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -62,6 +62,13 @@ var (
 		Usage:    "Allow that config-files contains deprecated fields",
 		Required: false,
 	}
+
+	healthcheckPort = cli.Uint64Flag{
+		Name:     "healthcheckPort",
+		Usage:    "Specify port for healthcheck. Default is 3000.",
+		Required: false,
+		Value:    3000,
+	}
 )
 
 func main() {
@@ -75,6 +82,7 @@ func main() {
 		&saveConfigFlag,
 		&disableDefaultConfigVars,
 		&allowDeprecatedFields,
+    &healthcheckPort,
 	}
 	app.Commands = []*cli.Command{
 		{


### PR DESCRIPTION
Expose healthcheck endpoint to allown k8s to detect pod liveness.

Expected usage: `cdk run --healthcheckPort XXXX`.