### PR TITLE
fix: seq sender oom while have large batch to sync

### DIFF
--- a/sequencesender/sequencesender.go
+++ b/sequencesender/sequencesender.go
@@ -25,7 +25,7 @@ import (
 )
 
 const ten = 10
-const multipleBatchSize = 3
+const multipleBatchSize = 5
 
 // EthTxManager represents the eth tx manager interface
 type EthTxManager interface {

--- a/sequencesender/sequencesender.go
+++ b/sequencesender/sequencesender.go
@@ -25,7 +25,7 @@ import (
 )
 
 const ten = 10
-const multipleBatchSize = 5
+const batchMultiplier = 5
 
 // EthTxManager represents the eth tx manager interface
 type EthTxManager interface {
@@ -216,7 +216,7 @@ func (s *SequenceSender) checkWait() bool {
 	s.mutexSequence.Lock()
 	defer s.mutexSequence.Unlock()
 
-	if uint64(len(s.sequenceList)) >= s.cfg.MaxBatchesForL1*multipleBatchSize {
+	if uint64(len(s.sequenceList)) >= s.cfg.MaxBatchesForL1*batchMultiplier {
 		s.logger.Infof("Sequence list is full: %d, waiting to sync batch from rpc.", len(s.sequenceList))
 		return true
 	}

--- a/sequencesender/sequencesender.go
+++ b/sequencesender/sequencesender.go
@@ -25,7 +25,7 @@ import (
 )
 
 const ten = 10
-const multipleBatchSize = 5
+const multipleBatchSize = 3
 
 // EthTxManager represents the eth tx manager interface
 type EthTxManager interface {

--- a/sequencesender/sequencesender.go
+++ b/sequencesender/sequencesender.go
@@ -25,6 +25,7 @@ import (
 )
 
 const ten = 10
+const multipleBatchSize = 5
 
 // EthTxManager represents the eth tx manager interface
 type EthTxManager interface {
@@ -176,6 +177,11 @@ func (s *SequenceSender) batchRetrieval(ctx context.Context) error {
 			s.logger.Info("context cancelled, stopping batch retrieval")
 			return ctx.Err()
 		default:
+			if s.checkWait() {
+				<-ticker.C
+				continue
+			}
+
 			// Try to retrieve batch from RPC
 			rpcBatch, err := s.rpcClient.GetBatch(currentBatchNumber)
 			if err != nil {
@@ -204,6 +210,17 @@ func (s *SequenceSender) batchRetrieval(ctx context.Context) error {
 			currentBatchNumber++
 		}
 	}
+}
+
+func (s *SequenceSender) checkWait() bool {
+	s.mutexSequence.Lock()
+	defer s.mutexSequence.Unlock()
+
+	if uint64(len(s.sequenceList)) >= s.cfg.MaxBatchesForL1*multipleBatchSize {
+		s.logger.Infof("Sequence list is full: %d, waiting to sync batch from rpc.", len(s.sequenceList))
+		return true
+	}
+	return false
 }
 
 func (s *SequenceSender) populateSequenceData(rpcBatch *types.RPCBatch, batchNumber uint64) error {


### PR DESCRIPTION
## Description

When a large number of batches are not commited to L1, the sequence sender will continuously request batches, eventually leading to out-of-memory (OOM) issue.

This PR can be avoided by limiting the maximum number of batches to synchronize.
Refer to https://github.com/0xPolygon/cdk/pull/249
