### PR TITLE
Check max timestamp before send to L1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ build-go:
 	$(GOENVVARS) go build -ldflags "all=$(LDFLAGS)" -o $(GOBIN)/$(GOBINARY) $(GOCMD)
 
 .PHONY: build-docker 
-build-docker: build-mock-signer-docker ## Builds a docker image with the cdk binary
+build-docker: ## Builds a docker image with the cdk binary
 	docker build -t cdk -f ./Dockerfile .
 
 .PHONY: build-mock-signer-docker

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -307,6 +307,11 @@ func newTxBuilder(
 	switch contracts.VersionType(cfg.Common.ContractVersions) {
 	case contracts.VersionBanana:
 		if cfg.Common.IsValidiumMode {
+			var l2RpcClient txbuilder.RPCInterface
+			if cfg.SequenceSender.CheckSendBatch {
+				l2RpcClient = rpc.NewBatchEndpoints(cfg.SequenceSender.RPCURL, cfg.SequenceSender.RPCTimeout.Duration)
+			}
+
 			txBuilder = txbuilder.NewTxBuilderBananaValidium(
 				logger,
 				ethman.Contracts.Banana.Rollup,
@@ -317,6 +322,7 @@ func newTxBuilder(
 				l1InfoTreeSync,
 				l1Client,
 				blockFinality,
+				l2RpcClient,
 			)
 		} else {
 			txBuilder = txbuilder.NewTxBuilderBananaZKEVM(

--- a/config/default.go
+++ b/config/default.go
@@ -92,6 +92,7 @@ MaxBatchesForL1 = 300
 BlockFinality = "FinalizedBlock"
 RPCURL = "{{L2URL}}"
 RPCTimeout = "60s"
+CheckSendBatch = false
 GetBatchWaitInterval = "10s"
 	[SequenceSender.EthTxManager]
 		FrequencyToMonitorTxs = "1s"

--- a/sequencesender/config.go
+++ b/sequencesender/config.go
@@ -71,6 +71,9 @@ type Config struct {
 	// RPCTimeout is the timeout for the L2 RPC calls
 	RPCTimeout types.Duration `mapstructure:"RPCTimeout"`
 
+	// CheckSendBatch is the configuration for the Batch before sending it to L1
+	CheckSendBatch bool `mapstructure:"CheckSendBatch"`
+
 	// GetBatchWaitInterval is the time to wait to query for a new batch when there are no more batches available
 	GetBatchWaitInterval types.Duration `mapstructure:"GetBatchWaitInterval"`
 }

--- a/sequencesender/txbuilder/banana_base.go
+++ b/sequencesender/txbuilder/banana_base.go
@@ -10,6 +10,7 @@ import (
 	"github.com/0xPolygon/cdk/etherman"
 	"github.com/0xPolygon/cdk/l1infotreesync"
 	"github.com/0xPolygon/cdk/log"
+	rpctypes "github.com/0xPolygon/cdk/rpc/types"
 	"github.com/0xPolygon/cdk/sequencesender/seqsendertypes"
 	"github.com/0xPolygon/cdk/state/datastream"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
@@ -35,6 +36,11 @@ type l1Client interface {
 	HeaderByNumber(ctx context.Context, number *big.Int) (*types.Header, error)
 }
 
+// RPCInterface represents the RPC interface
+type RPCInterface interface {
+	GetBatch(batchNumber uint64) (*rpctypes.RPCBatch, error)
+}
+
 type TxBuilderBananaBase struct {
 	logger                 *log.Logger
 	rollupContract         rollupBananaBaseContractor
@@ -43,6 +49,7 @@ type TxBuilderBananaBase struct {
 	ethClient              l1Client
 	blockFinality          *big.Int
 	opts                   bind.TransactOpts
+	l2RpcClient            RPCInterface
 }
 
 func NewTxBuilderBananaBase(
@@ -53,6 +60,7 @@ func NewTxBuilderBananaBase(
 	ethClient l1Client,
 	blockFinality *big.Int,
 	opts bind.TransactOpts,
+	l2RpcClient RPCInterface,
 ) *TxBuilderBananaBase {
 	return &TxBuilderBananaBase{
 		logger:                 logger,
@@ -62,6 +70,7 @@ func NewTxBuilderBananaBase(
 		ethClient:              ethClient,
 		blockFinality:          blockFinality,
 		opts:                   opts,
+		l2RpcClient:            l2RpcClient,
 	}
 }
 

--- a/sequencesender/txbuilder/banana_base_test.go
+++ b/sequencesender/txbuilder/banana_base_test.go
@@ -148,6 +148,7 @@ func newBananaBaseTestData(t *testing.T) *testDataBananaBase {
 		zkevmContractMock,
 		gerContractMock,
 		l1InfoSyncer, l1Client, big.NewInt(0), opts,
+		nil,
 	)
 	require.NotNil(t, sut)
 	return &testDataBananaBase{

--- a/sequencesender/txbuilder/banana_validium_test.go
+++ b/sequencesender/txbuilder/banana_validium_test.go
@@ -104,6 +104,7 @@ func newBananaValidiumTestData(t *testing.T, maxBatchesForL1 uint64) *testDataBa
 		l1InfoSyncer,
 		l1Client,
 		big.NewInt(0),
+		nil,
 	)
 	require.NotNil(t, sut)
 	sut.SetCondNewSeq(condMock)

--- a/sequencesender/txbuilder/banana_zkevm.go
+++ b/sequencesender/txbuilder/banana_zkevm.go
@@ -46,7 +46,7 @@ func NewTxBuilderBananaZKEVM(
 	blockFinality *big.Int,
 ) *TxBuilderBananaZKEVM {
 	txBuilderBase := *NewTxBuilderBananaBase(logger, rollupContract,
-		gerContract, l1InfoTree, ethClient, blockFinality, opts)
+		gerContract, l1InfoTree, ethClient, blockFinality, opts, nil)
 
 	return &TxBuilderBananaZKEVM{
 		TxBuilderBananaBase: txBuilderBase,

--- a/test/config/test.config.toml
+++ b/test/config/test.config.toml
@@ -15,6 +15,7 @@ WaitPeriodPurgeTxFile = "60m"
 MaxPendingTx = 1
 RPCURL = "http://127.0.0.1:8123"
 GetBatchWaitInterval = "10s"
+CheckSendBatch = false
 	[SequenceSender.EthTxManager]
 		FrequencyToMonitorTxs = "1s"
 		WaitTxToBeMined = "2m"


### PR DESCRIPTION
## Description
- X Layer mainnet got an issue while the max timestamp is error
- Recheck the timestamp for sequencer before send to L1.
- Only for banana validium mode